### PR TITLE
improve performance

### DIFF
--- a/Dash.js
+++ b/Dash.js
@@ -5,56 +5,45 @@
 */
 
 import React from 'react'
-import { View } from 'react-native'
+import { View, StyleSheet } from 'react-native'
 import MeasureMeHOC from 'react-native-measureme'
+import { getDashStyle, isStyleRow } from './util'
 
-const Dash = (
-	{
-		dashGap,
-		dashLength,
-		dashThickness,
-		dashStyle,
-		style = {},
-		...props,
-	}) => {
-	let length = props.width
-	let { flexDirection = 'row' } = style
-	let width = dashLength
-	let height = dashThickness
-	let marginRight = dashGap
-	let marginBottom = 0
-	if (flexDirection === 'column') {
-		length = props.height
-		width = dashThickness
-		height = dashLength
-		marginRight = 0
-		marginBottom = dashGap
-	}
-
-	let n = Math.ceil(length / (dashGap + dashLength))
+const Dash = (props) => {
+	const isRow = isStyleRow(props.style)
+	const length = isRow ? props.width : props.height
+	const n = Math.ceil(length / (props.dashGap + props.dashLength))
+    const calculatedDashStyles = getDashStyle(props)
 	let dash = []
 	for (let i = 0; i < n; i++) {
 		dash.push(
 			<View
 				key={ i }
 				style={ [
-					dashStyle,
-					{
-						width,
-						height,
-						marginRight,
-						marginBottom,
-					},
+					props.dashStyle,
+					calculatedDashStyles,
 				] }
 			/>
 		)
 	}
 	return (
-		<View style={ [ style, { flexDirection } ] }>
+		<View style={ [ props.style, isRow ? styles.dashRow : styles.dashColumn ] }>
 			{ dash }
 		</View>
 	)
 }
+
+const styles = StyleSheet.create({
+	dashDefault: {
+		backgroundColor: 'black',
+	},
+	dashRow: {
+		flexDirection: 'row',
+	},
+	dashColumn: {
+		flexDirection: 'column',
+	},
+})
 
 Dash.propTypes = {
 	style: View.propTypes.style,
@@ -69,7 +58,7 @@ Dash.defaultProps = {
 	dashGap: 2,
 	dashLength: 4,
 	dashThickness: 2,
-	dashStyle: { backgroundColor: 'black' }
+	dashStyle: styles.dashDefault,
 }
 
 module.exports = MeasureMeHOC(Dash)

--- a/util.js
+++ b/util.js
@@ -1,0 +1,35 @@
+import { StyleSheet } from 'react-native'
+
+export const isStyleRow = (style) => {
+	const flatStyle = StyleSheet.flatten(style)
+	return flatStyle.flexDirection !== 'column'
+}
+
+const getDashStyleId = ({ dashGap, dashLength, dashThickness }, isRow) => {
+	return `${dashGap}-${dashLength}-${dashThickness}-${isRow ? 'row' : 'column'}`
+}
+
+const createDashStyleSheet = ({ dashGap, dashLength, dashThickness, style }, isRow) => {
+	const idStyle = new StyleSheet.create({
+		style: {
+			width: isRow ? dashLength : dashThickness,
+			height: isRow ? dashThickness : dashLength,
+			marginRight: isRow ? dashGap : 0,
+			marginBottom: isRow ? 0 : dashGap,
+		},
+	})
+	return idStyle.style
+}
+
+const stylesStore = {}
+export const getDashStyle = (props) => {
+	const isRow = isStyleRow(props.style)
+	const id = getDashStyleId(props, isRow)
+	if (!stylesStore[ id ]) {
+		stylesStore = {
+			...stylesStore,
+			[ id ]: createDashStyleSheet(props, isRow),
+		}
+	}
+	return stylesStore[ id ]
+}


### PR DESCRIPTION
For every dash in the component, a new style was created and thus
and a new object is allocated in memory which also has to be sent
over the native bridge. This is a performance intensive task
and may lead to jank.

See https://facebook.github.io/react-native/docs/stylesheet.html
for further information.

This commit introduces the use of StyleSheet.create to create
reusable styles and stores them by an id to reference them later
for dashes with the same styling.

I tried to align as much as possible on the rules used in your project but there was no .eslintrc or something else to align on, I hope this matches your preferences.