### PR TITLE
reimplement dashColor property

### DIFF
--- a/Dash.js
+++ b/Dash.js
@@ -13,15 +13,15 @@ const Dash = (props) => {
 	const isRow = isStyleRow(props.style)
 	const length = isRow ? props.width : props.height
 	const n = Math.ceil(length / (props.dashGap + props.dashLength))
-    const calculatedDashStyles = getDashStyle(props)
+	const calculatedDashStyles = getDashStyle(props)
 	let dash = []
 	for (let i = 0; i < n; i++) {
 		dash.push(
 			<View
 				key={ i }
 				style={ [
-					props.dashStyle,
 					calculatedDashStyles,
+					props.dashStyle,
 				] }
 			/>
 		)
@@ -34,9 +34,6 @@ const Dash = (props) => {
 }
 
 const styles = StyleSheet.create({
-	dashDefault: {
-		backgroundColor: 'black',
-	},
 	dashRow: {
 		flexDirection: 'row',
 	},
@@ -58,7 +55,7 @@ Dash.defaultProps = {
 	dashGap: 2,
 	dashLength: 4,
 	dashThickness: 2,
-	dashStyle: styles.dashDefault,
+	dashColor: 'black',
 }
 
 module.exports = MeasureMeHOC(Dash)

--- a/util.js
+++ b/util.js
@@ -1,21 +1,21 @@
 import { StyleSheet } from 'react-native'
 
 export const isStyleRow = (style) => {
-	const flatStyle = StyleSheet.flatten(style)
+	const flatStyle = StyleSheet.flatten(style);
 	return flatStyle.flexDirection !== 'column'
 }
 
-const getDashStyleId = ({ dashGap, dashLength, dashThickness }, isRow) => {
-	return `${dashGap}-${dashLength}-${dashThickness}-${isRow ? 'row' : 'column'}`
-}
+const getDashStyleId = ({ dashGap, dashLength, dashThickness, dashColor }, isRow) =>
+	`${dashGap}-${dashLength}-${dashThickness}-${dashColor}-${isRow ? 'row' : 'column'}`
 
-const createDashStyleSheet = ({ dashGap, dashLength, dashThickness, style }, isRow) => {
+const createDashStyleSheet = ({ dashGap, dashLength, dashThickness, dashColor }, isRow) => {
 	const idStyle = new StyleSheet.create({
 		style: {
 			width: isRow ? dashLength : dashThickness,
 			height: isRow ? dashThickness : dashLength,
 			marginRight: isRow ? dashGap : 0,
 			marginBottom: isRow ? 0 : dashGap,
+			backgroundColor: dashColor,
 		},
 	})
 	return idStyle.style


### PR DESCRIPTION
As discussed in #5 this PR will bring the `dashColor` property back. It is also possible to override it by setting the `backgroundColor` via `dashStyle` property (all generated styles are now able to be overridden by `dashStyle`).