### PR TITLE
do not throw for undefined style property

### DIFF
--- a/util.js
+++ b/util.js
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native'
 
 export const isStyleRow = (style) => {
-	const flatStyle = StyleSheet.flatten(style)
+	const flatStyle = StyleSheet.flatten(style || {})
 	return flatStyle.flexDirection !== 'column'
 }
 


### PR DESCRIPTION
When no style property is defined, StyleSheet.flatten will
return undefined which throws an error when accessed to get
the flex direction.
To fix it this commit will add an empty object as a fallback.

This is an issue I introduced with #4. It would be good to have this merged before creating a new npm package.