### PR TITLE
Update View.propTypes

### DIFF
--- a/Dash.js
+++ b/Dash.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { View, StyleSheet } from 'react-native'
+import { View, StyleSheet, ViewPropTypes } from 'react-native'
 import MeasureMeHOC from 'react-native-measureme'
 import { getDashStyle, isStyleRow } from './util'
 
@@ -47,7 +47,7 @@ const styles = StyleSheet.create({
 })
 
 Dash.propTypes = {
-	style: View.propTypes.style,
+	style: ViewPropTypes.style,
 	dashGap: PropTypes.number.isRequired,
 	dashLength: PropTypes.number.isRequired,
 	dashThickness: PropTypes.number.isRequired,

--- a/Dash.js
+++ b/Dash.js
@@ -52,7 +52,7 @@ Dash.propTypes = {
 	dashLength: PropTypes.number.isRequired,
 	dashThickness: PropTypes.number.isRequired,
 	dashColor: PropTypes.string,
-	dashStyle: View.propTypes.style,
+	dashStyle: ViewPropTypes.style,
 }
 
 Dash.defaultProps = {


### PR DESCRIPTION
`View.propTypes` has been deprecated and `ViewPropTypes` should be used instead. This might be a breaking change, as it may break older versions of react native.