### PR TITLE
fix: remove redundant `new` keyword

### DIFF
--- a/util.js
+++ b/util.js
@@ -17,7 +17,7 @@ const createDashStyleSheet = (
   { dashGap, dashLength, dashThickness, dashColor },
   isRow
 ) => {
-  const idStyle = new StyleSheet.create({
+  const idStyle = StyleSheet.create({
     style: {
       width: isRow ? dashLength : dashThickness,
       height: isRow ? dashThickness : dashLength,


### PR DESCRIPTION
Stylesheet.create does not require new keyword for creating a new instance. This is causing a crash on Android with React Native 0.59 if a modern babel config is used.