### PR TITLE
remove ViewPropTypes

### DIFF
--- a/Dash.js
+++ b/Dash.js
@@ -43,12 +43,16 @@ const styles = StyleSheet.create({
 })
 
 Dash.propTypes = {
-	style: ViewPropTypes.style,
+	style: PropTypes.shape({
+    style: PropTypes.any,
+  }),
 	dashGap: PropTypes.number.isRequired,
 	dashLength: PropTypes.number.isRequired,
 	dashThickness: PropTypes.number.isRequired,
 	dashColor: PropTypes.string,
-	dashStyle: ViewPropTypes.style,
+	dashStyle: PropTypes.shape({
+    style: PropTypes.any,
+  }),
 }
 
 Dash.defaultProps = {

--- a/Dash.js
+++ b/Dash.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { View, StyleSheet, ViewPropTypes } from 'react-native'
+import { View, StyleSheet } from 'react-native'
 import MeasureMeHOC from 'react-native-measureme'
 import { getDashStyle, isStyleRow } from '../util'
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ npm i --save react-native-dash
 ## Props
 | name | desc | type | default
 | --- | --- | --- | --- |
-| `style` | Dash container style  | [View.PropTypes.Style](https://facebook.github.io/react-native/docs/view.html#style) | `{flexDirection = 'row'}`
+| `style` | Dash container style  | ViewProps.shape({style: ViewProps.any}) | `{flexDirection = 'row'}`
 | `dashGap` | Gap between two dashes | number | `2`
 | `dashLength` | Length of each dash | number | `4`
 | `dashThickness` | Thickness of each dash | number | `2`
 | `dashColor` | Color of each dash | string | `black`
-| `dashStyle` | Dashes style | [View.PropTypes.Style](https://facebook.github.io/react-native/docs/view.html#style) | {}
+| `dashStyle` | Dashes style | ViewProps.shape({style: ViewProps.any}) | {}
 
  - **ProTip 1**: Use `flexDirection` in style to get horizontal or vertical dashes. By default, it's `row`
  - **ProTip 2**: Use `{borderRadius: 100, overflow: 'hidden'}` in dashStyle to get rounded dotes instead of straight line dashes. 

--- a/dist/index.js
+++ b/dist/index.js
@@ -54,12 +54,16 @@ var styles = _reactNative.StyleSheet.create({
 });
 
 Dash.propTypes = {
-	style: _reactNative.ViewPropTypes.style,
+	style: _propTypes2.default.shape({
+		style: _propTypes2.default.any
+	}),
 	dashGap: _propTypes2.default.number.isRequired,
 	dashLength: _propTypes2.default.number.isRequired,
 	dashThickness: _propTypes2.default.number.isRequired,
 	dashColor: _propTypes2.default.string,
-	dashStyle: _reactNative.ViewPropTypes.style
+	dashStyle: _propTypes2.default.shape({
+		style: _propTypes2.default.any
+	})
 };
 
 Dash.defaultProps = {


### PR DESCRIPTION
Removed references to `ViewPropTypes`, a deprecated type from the `react-native` package. The new setup should allow for web support, as `react-native-web` hasn't supported `ViewPropTypes` since its version 0.12 (now on 0.17.5).

Should fix #37 